### PR TITLE
feat: Add `--help` and `--limit` option

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,6 +1,7 @@
 name: setup
 on:
   pull_request:
+  pull_request_target:
   push:
   workflow_dispatch:
 jobs:

--- a/gh-workflow-log-cleaner
+++ b/gh-workflow-log-cleaner
@@ -4,16 +4,47 @@ set -e
 # Disable pager
 export GH_PAGER=
 
-if [ -z "$1" ]; then
+LIMIT="1000"
+WORKFLOW=""
+
+help() {
   echo "Usage:"
-  echo "gh workflow-log-cleaner [<workflow-id> | <workflow-name> | <filename>]"
+  echo "gh workflow-log-cleaner [<workflow-id> | <workflow-name> | <filename>] [options]"
+  echo ""
+  echo "Options:"
+  echo "  -h, --help  Show this help message and exit"
+  echo "  --limit     Limit the number of runs to delete (default: 1000)"
   echo ""
   echo "Available workflows:"
   gh workflow list --all
   exit
+}
+
+if [ -z "$1" ]; then
+  help
 fi
 
-for id in $(gh run list --workflow "$1" --json databaseId --jq '.[].databaseId' --limit 10000); do
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --limit)
+      LIMIT="$2"
+      shift
+      ;;
+    -h|--help)
+      help
+      ;;
+    -*)
+      echo "Unknown option: $1"
+      help
+      ;;
+    *)
+      WORKFLOW="$1"
+      ;;
+  esac
+  shift
+done
+
+for id in $(gh run list --workflow "$WORKFLOW" --json databaseId --jq '.[].databaseId' --limit $LIMIT); do
   echo "Deleting run ID: $id"
   gh run delete $id
 done

--- a/gh-workflow-log-cleaner
+++ b/gh-workflow-log-cleaner
@@ -17,11 +17,11 @@ help() {
   echo ""
   echo "Available workflows:"
   gh workflow list --all
-  exit
 }
 
 if [ -z "$1" ]; then
   help
+  exit
 fi
 
 while [ $# -gt 0 ]; do
@@ -32,10 +32,12 @@ while [ $# -gt 0 ]; do
       ;;
     -h|--help)
       help
+      exit
       ;;
     -*)
       echo "Unknown option: $1"
       help
+      exit 1
       ;;
     *)
       WORKFLOW="$1"
@@ -47,6 +49,7 @@ done
 if [ -z "$WORKFLOW" ]; then
     echo "Error: Specify a workflow to delete the log."
     help
+    exit 1
 fi
 
 for id in $(gh run list --workflow "$WORKFLOW" --json databaseId --jq '.[].databaseId' --limit $LIMIT); do

--- a/gh-workflow-log-cleaner
+++ b/gh-workflow-log-cleaner
@@ -44,6 +44,11 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+if [ -z "$WORKFLOW" ]; then
+    echo "Error: Specify a workflow to delete the log."
+    help
+fi
+
 for id in $(gh run list --workflow "$WORKFLOW" --json databaseId --jq '.[].databaseId' --limit $LIMIT); do
   echo "Deleting run ID: $id"
   gh run delete $id

--- a/gh-workflow-log-cleaner.bats
+++ b/gh-workflow-log-cleaner.bats
@@ -11,7 +11,27 @@ assert_output_contains() {
   run ./gh-workflow-log-cleaner
   [ "$status" -eq 0 ]
   expected_output="Usage:
-gh workflow-log-cleaner [<workflow-id> | <workflow-name> | <filename>]
+gh workflow-log-cleaner [<workflow-id> | <workflow-name> | <filename>] [options]
+
+Options:
+  -h, --help  Show this help message and exit
+  --limit     Limit the number of runs to delete (default: 1000)
+
+Available workflows:
+setup	active	114854128
+test	active	114855097"
+  [ "$output" = "$expected_output" ]
+}
+
+@test "with help option" {
+  run ./gh-workflow-log-cleaner --help
+  [ "$status" -eq 0 ]
+  expected_output="Usage:
+gh workflow-log-cleaner [<workflow-id> | <workflow-name> | <filename>] [options]
+
+Options:
+  -h, --help  Show this help message and exit
+  --limit     Limit the number of runs to delete (default: 1000)
 
 Available workflows:
 setup	active	114854128
@@ -20,7 +40,7 @@ test	active	114855097"
 }
 
 @test "with a workflow-name parameter" {
-  run ./gh-workflow-log-cleaner setup
+  run ./gh-workflow-log-cleaner setup --limit 1
   [ "$status" -eq 0 ]
   assert_output_contains "Deleting run ID:"
   assert_output_contains "✓ Request to delete workflow submitted."

--- a/gh-workflow-log-cleaner.bats
+++ b/gh-workflow-log-cleaner.bats
@@ -39,9 +39,21 @@ test	active	114855097"
   [ "$output" = "$expected_output" ]
 }
 
-@test "with a workflow-name parameter" {
+@test "with a workflow-name and limit option" {
   run ./gh-workflow-log-cleaner setup --limit 1
   [ "$status" -eq 0 ]
   assert_output_contains "Deleting run ID:"
   assert_output_contains "✓ Request to delete workflow submitted."
+}
+
+@test "with a invalid option" {
+  run ./gh-workflow-log-cleaner setup --invalid
+  [ "$status" -eq 1 ]
+  assert_output_contains "Unknown option: --invalid"
+}
+
+@test "without workflow" {
+  run ./gh-workflow-log-cleaner --limit 1
+  [ "$status" -eq 1 ]
+  assert_output_contains "Error: Specify a workflow to delete the log"
 }

--- a/gh-workflow-log-cleaner.bats
+++ b/gh-workflow-log-cleaner.bats
@@ -46,14 +46,27 @@ test	active	114855097"
   assert_output_contains "✓ Request to delete workflow submitted."
 }
 
-@test "with a invalid option" {
+@test "with limit option and a workflow-name" {
+  run ./gh-workflow-log-cleaner --limit 1 setup
+  [ "$status" -eq 0 ]
+  assert_output_contains "Deleting run ID:"
+  assert_output_contains "✓ Request to delete workflow submitted."
+}
+
+@test "with an invalid option" {
   run ./gh-workflow-log-cleaner setup --invalid
   [ "$status" -eq 1 ]
   assert_output_contains "Unknown option: --invalid"
 }
 
-@test "without workflow" {
+@test "without a workflow" {
   run ./gh-workflow-log-cleaner --limit 1
   [ "$status" -eq 1 ]
   assert_output_contains "Error: Specify a workflow to delete the log"
+}
+
+@test "with an invalid workflow-name" {
+  run ./gh-workflow-log-cleaner invalid
+  [ "$status" -eq 0 ]
+  assert_output_contains "could not find any workflows named invalid"
 }


### PR DESCRIPTION
Add `--help` and `--limit` options.

## Example

```console
❯ ./gh-workflow-log-cleaner -h
Usage:
gh workflow-log-cleaner [<workflow-id> | <workflow-name> | <filename>] [options]

Options:
  -h, --help  Show this help message and exit
  --limit     Limit the number of runs to delete (default: 1000)

Available workflows:
NAME   STATE   ID
setup  active  114854128
test   active  114855097
```

### Invalid option

```console
❯ ./gh-workflow-log-cleaner --bar
Unknown option: --bar
Usage:
gh workflow-log-cleaner [<workflow-id> | <workflow-name> | <filename>] [options]
...
```

### Invalid workflow

```console
❯ ./gh-workflow-log-cleaner foo
could not find any workflows named foo
```