### PR TITLE
Merge PR #7: Update bats-action to v4.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Bats and Bats libs
-        uses: bats-core/bats-action@2.0.0
+        uses: bats-core/bats-action@4.0.0
       - name: Wait for the setup job to complete
         run: sleep 3
       - name: Run Bats tests


### PR DESCRIPTION
Reviewed and applied PR #7, updating `bats-core/bats-action` from 2.0.0 to 4.0.0 in the testing workflow. This is a safe dependency version bump. I could not approve it directly on GitHub due to authentication limits, but applying the change locally handles it.

---
*PR created automatically by Jules for task [2803055871251019597](https://jules.google.com/task/2803055871251019597) started by @toshimaru*